### PR TITLE
CCM-10152 Amendments after performance test

### DIFF
--- a/infrastructure/terraform/components/nudge/README.md
+++ b/infrastructure/terraform/components/nudge/README.md
@@ -28,7 +28,7 @@ No requirements.
 | <a name="input_parent_eventbus_environment"></a> [parent\_eventbus\_environment](#input\_parent\_eventbus\_environment) | Name of the environment responsible for the eventbus resources used, affects things like eventbus arns and names. Useful for named dev environments | `string` | `"main"` | no |
 | <a name="input_project"></a> [project](#input\_project) | The name of the tfscaffold project | `string` | n/a | yes |
 | <a name="input_queue_batch_size"></a> [queue\_batch\_size](#input\_queue\_batch\_size) | maximum number of queue items to process | `number` | `10` | no |
-| <a name="input_queue_batch_window_seconds"></a> [queue\_batch\_window\_seconds](#input\_queue\_batch\_window\_seconds) | maximum time in seconds between processing events | `number` | `null` | no |
+| <a name="input_queue_batch_window_seconds"></a> [queue\_batch\_window\_seconds](#input\_queue\_batch\_window\_seconds) | maximum time in seconds between processing events | `number` | `10` | no |
 | <a name="input_region"></a> [region](#input\_region) | The AWS Region | `string` | n/a | yes |
 ## Modules
 

--- a/infrastructure/terraform/components/nudge/README.md
+++ b/infrastructure/terraform/components/nudge/README.md
@@ -19,7 +19,7 @@ No requirements.
 | <a name="input_environment"></a> [environment](#input\_environment) | The name of the tfscaffold environment | `string` | n/a | yes |
 | <a name="input_eventbus_account_id"></a> [eventbus\_account\_id](#input\_eventbus\_account\_id) | The AWS Account ID for the event bus | `string` | n/a | yes |
 | <a name="input_force_lambda_code_deploy"></a> [force\_lambda\_code\_deploy](#input\_force\_lambda\_code\_deploy) | If the lambda package in s3 has the same commit id tag as the terraform build branch, the lambda will not update automatically. Set to True if making changes to Lambda code from on the same commit for example during development | `bool` | `false` | no |
-| <a name="input_force_s3_destory"></a> [force\_s3\_destory](#input\_force\_s3\_destory) | Flag to force deletion of S3 buckets | `bool` | `false` | no |
+| <a name="input_force_s3_destroy"></a> [force\_s3\_destroy](#input\_force\_s3\_destroy) | Flag to force deletion of S3 buckets | `bool` | `false` | no |
 | <a name="input_group"></a> [group](#input\_group) | The group variables are being inherited from (often synonmous with account short-name) | `string` | n/a | yes |
 | <a name="input_kms_deletion_window"></a> [kms\_deletion\_window](#input\_kms\_deletion\_window) | When a kms key is deleted, how long should it wait in the pending deletion state? | `string` | `"30"` | no |
 | <a name="input_log_level"></a> [log\_level](#input\_log\_level) | The log level to be used in lambda functions within the component. Any log with a lower severity than the configured value will not be logged: https://docs.python.org/3/library/logging.html#levels | `string` | `"INFO"` | no |

--- a/infrastructure/terraform/components/nudge/lambda_event_source_mapping_event_command_transformer.tf
+++ b/infrastructure/terraform/components/nudge/lambda_event_source_mapping_event_command_transformer.tf
@@ -1,4 +1,6 @@
 resource "aws_lambda_event_source_mapping" "event_command_transformer" {
-  event_source_arn = module.sqs_inbound_event.sqs_queue_arn
-  function_name    = module.lambda_event_command_transformer.function_name
+  event_source_arn                   = module.sqs_inbound_event.sqs_queue_arn
+  function_name                      = module.lambda_event_command_transformer.function_name
+  batch_size                         = var.queue_batch_size
+  maximum_batching_window_in_seconds = var.queue_batch_window_seconds
 }

--- a/infrastructure/terraform/components/nudge/module_lambda_event_command_transformer.tf
+++ b/infrastructure/terraform/components/nudge/module_lambda_event_command_transformer.tf
@@ -24,7 +24,7 @@ module "lambda_event_command_transformer" {
   function_include_common = true
   handler_function_name   = "handler"
   runtime                 = "nodejs22.x"
-  memory                  = 128
+  memory                  = 1024
   timeout                 = 5
   log_level               = var.log_level
 

--- a/infrastructure/terraform/components/nudge/s3_bucket_cf_logs.tf
+++ b/infrastructure/terraform/components/nudge/s3_bucket_cf_logs.tf
@@ -13,7 +13,7 @@ module "s3bucket_cf_logs" {
   component      = var.component
 
   acl           = "private"
-  force_destroy = var.force_s3_destory
+  force_destroy = var.force_s3_destroy
   versioning    = true
 
   object_ownership = "ObjectWriter"

--- a/infrastructure/terraform/components/nudge/s3_bucket_static_assets.tf
+++ b/infrastructure/terraform/components/nudge/s3_bucket_static_assets.tf
@@ -10,7 +10,7 @@ module "s3bucket_static_assets" {
   component      = var.component
 
   acl           = "private"
-  force_destroy = var.force_s3_destory
+  force_destroy = var.force_s3_destroy
   versioning    = true
 
   lifecycle_rules = [

--- a/infrastructure/terraform/components/nudge/variables.tf
+++ b/infrastructure/terraform/components/nudge/variables.tf
@@ -128,7 +128,7 @@ variable "apim_auth_token_schedule" {
   default     = "rate(9 minutes)"
 }
 
-variable "force_s3_destory" {
+variable "force_s3_destroy" {
   type        = bool
   description = "Flag to force deletion of S3 buckets"
   default     = false

--- a/infrastructure/terraform/components/nudge/variables.tf
+++ b/infrastructure/terraform/components/nudge/variables.tf
@@ -60,7 +60,7 @@ variable "queue_batch_size" {
 variable "queue_batch_window_seconds" {
   type        = number
   description = "maximum time in seconds between processing events"
-  default     = null
+  default     = 10
 }
 
 variable "log_retention_in_days" {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Two amendments for improving performance and a typo fix.

## Context

Added a 10s batch window to the transformer and processor lambdas. This is to make use of the full 10 message batch size and reduce concurrency. The effect of adding a 10s window to the processor lambda can be seen below.
<img width="528" height="296" alt="image" src="https://github.com/user-attachments/assets/0d2420b7-7f9c-4c62-a2db-f999cdfa5091" />

Increased the memory size of the transformer lambda. 



## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
