### PR TITLE
CCM-11730: Handle Duplicate Unnotified Callbacks

### DIFF
--- a/lambdas/command-processor/src/__tests__/app/command-processor-service.test.ts
+++ b/lambdas/command-processor/src/__tests__/app/command-processor-service.test.ts
@@ -61,8 +61,10 @@ describe('CommandProcessorService', () => {
   });
 
   it('does not re-throw when a RequestAlreadyReceivedError is thrown by the API client', async () => {
+    const { messageReference } = mockRequest.data.attributes;
     const err = new RequestAlreadyReceivedError(
-      'The request has already been received by the Notify API',
+      new Error('Request was already received!'),
+      messageReference,
     );
     mockClient.sendRequest.mockRejectedValue(err);
 
@@ -71,7 +73,7 @@ describe('CommandProcessorService', () => {
     expect(mockLogger.info).toHaveBeenCalledWith(
       'Request has already been received by Notify',
       {
-        messageReference: mockRequest.data.attributes.messageReference,
+        messageReference,
         err,
       },
     );

--- a/lambdas/command-processor/src/__tests__/app/command-processor-service.test.ts
+++ b/lambdas/command-processor/src/__tests__/app/command-processor-service.test.ts
@@ -74,7 +74,6 @@ describe('CommandProcessorService', () => {
       'Request has already been received by Notify',
       {
         messageReference,
-        err,
       },
     );
   });

--- a/lambdas/command-processor/src/app/command-processor-service.ts
+++ b/lambdas/command-processor/src/app/command-processor-service.ts
@@ -37,7 +37,6 @@ export class CommandProcessorService {
       if (error instanceof RequestAlreadyReceivedError) {
         this.logger.info('Request has already been received by Notify', {
           messageReference,
-          err: error,
         });
         return;
       }

--- a/lambdas/command-processor/src/app/command-processor-service.ts
+++ b/lambdas/command-processor/src/app/command-processor-service.ts
@@ -1,6 +1,7 @@
 import { Logger } from 'nhs-notify-sms-nudge-utils/logger';
 import type { NotifyClient } from 'app/notify-api-client';
 import type { SingleMessageRequest } from 'domain/request';
+import { RequestAlreadyReceivedError } from 'domain/request-already-received-error';
 
 type Dependencies = {
   nhsNotifyClient: NotifyClient;
@@ -33,6 +34,11 @@ export class CommandProcessorService {
         messageItemId: response.data.id,
       });
     } catch (error: any) {
+      if (error instanceof RequestAlreadyReceivedError) {
+        this.logger.info('Request has already been received by Notify');
+        return;
+      }
+
       this.logger.error('Failed processing request', {
         messageReference,
         error: error.message,

--- a/lambdas/command-processor/src/app/command-processor-service.ts
+++ b/lambdas/command-processor/src/app/command-processor-service.ts
@@ -35,7 +35,10 @@ export class CommandProcessorService {
       });
     } catch (error: any) {
       if (error instanceof RequestAlreadyReceivedError) {
-        this.logger.info('Request has already been received by Notify');
+        this.logger.info('Request has already been received by Notify', {
+          messageReference,
+          err: error,
+        });
         return;
       }
 

--- a/lambdas/command-processor/src/app/notify-api-client.ts
+++ b/lambdas/command-processor/src/app/notify-api-client.ts
@@ -98,7 +98,7 @@ export class NotifyClient implements INotifyClient, IAccessibleService {
         error.response?.status ===
           HTTP2_CONSTANTS.HTTP_STATUS_UNPROCESSABLE_ENTITY
       ) {
-        throw new RequestAlreadyReceivedError('Request already received');
+        throw new RequestAlreadyReceivedError(error, correlationId);
       }
 
       throw error;

--- a/lambdas/command-processor/src/app/notify-api-client.ts
+++ b/lambdas/command-processor/src/app/notify-api-client.ts
@@ -95,7 +95,7 @@ export class NotifyClient implements INotifyClient, IAccessibleService {
 
       if (
         isAxiosError(error) &&
-        error.response.status ===
+        error.response?.status ===
           HTTP2_CONSTANTS.HTTP_STATUS_UNPROCESSABLE_ENTITY
       ) {
         throw new RequestAlreadyReceivedError('Request already received');

--- a/lambdas/command-processor/src/app/notify-api-client.ts
+++ b/lambdas/command-processor/src/app/notify-api-client.ts
@@ -11,6 +11,7 @@ import {
   conditionalRetry,
 } from 'nhs-notify-sms-nudge-utils';
 import type { Logger } from 'nhs-notify-sms-nudge-utils';
+import { RequestAlreadyReceivedError } from 'domain/request-already-received-error';
 
 export interface IAccessTokenRepository {
   getAccessToken(): Promise<string>;
@@ -91,6 +92,15 @@ export class NotifyClient implements INotifyClient, IAccessibleService {
         description: 'Failed sending SMS request',
         err: error,
       });
+
+      if (
+        isAxiosError(error) &&
+        error.response.status ===
+          HTTP2_CONSTANTS.HTTP_STATUS_UNPROCESSABLE_ENTITY
+      ) {
+        throw new RequestAlreadyReceivedError('Request already received');
+      }
+
       throw error;
     }
   }

--- a/lambdas/command-processor/src/domain/request-already-received-error.ts
+++ b/lambdas/command-processor/src/domain/request-already-received-error.ts
@@ -1,3 +1,12 @@
 export class RequestAlreadyReceivedError extends Error {
-  // It might be useful to have this contain some details of the request and the root cause.
+  readonly cause: Error;
+
+  readonly correlationId: string;
+
+  constructor(cause: Error, correlationId: string) {
+    super('The request has already been received.');
+
+    this.cause = cause;
+    this.correlationId = correlationId;
+  }
 }

--- a/lambdas/command-processor/src/domain/request-already-received-error.ts
+++ b/lambdas/command-processor/src/domain/request-already-received-error.ts
@@ -1,0 +1,3 @@
+export class RequestAlreadyReceivedError extends Error {
+  // It might be useful to have this contain some details of the request and the root cause.
+}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR updates the command-processer lambda so that it does not treat HTTP 422 errors returned from the NHS Notify API as fatal errors and does not push the message that resulted in the 422 onto the DLQ.

I have taken the approach of having the `NotifyClient` class handle checking the HTTP response status, as this keeps the details of interaction with the API encapsulated within the class and it then throws a new error type if a 422 error is received. The `CommandProcessorService` class is then responsible for determining whether the error from the API client is treated as fatal or not.

## Context

We seem to sometimes be getting duplicate Unnotified callbacks. When that happens the NHS App Callback Lambda triggers duplicate status change events, which then causes the nudge component to send a duplicate NHS Notify API request which eventually fails with a 422 error code because it doesn't accept duplicate message reference.

When that happens Nudges are still sent to patients and duplicates are ignored by the NHS Notify API but it still results in the Nudge Command lambda adding items to its DLQ, which then needs to be purged.

## Verification

1. Using the AWS console, manually updated the configuration of the command-processor lambda deployed for this PR to match that of the one deployed for `main`, so that it will make requests to the INT instance of the Notify API:
<img width="1342" height="292" alt="Screenshot 2025-08-21 at 15 59 59" src="https://github.com/user-attachments/assets/828b730d-ec36-4357-8956-a1191b423c5c" />

2. Manually updated the permissions of the `nhs-pr74-nudge-command-processor` IAM role so that it had access to read the APIM access token from the parameter store entry for `main`.

3. Manually sent two requests immediately after each other to the Nudge inbound event queue for this environment (`nhs-pr74-nudge-inbound-event-queue`:
<img width="1847" height="1173" alt="Screenshot 2025-08-21 at 16 04 53" src="https://github.com/user-attachments/assets/0bfeae8a-03e6-4205-baf6-551da1b385de" />
<img width="1847" height="1173" alt="Screenshot 2025-08-21 at 16 05 01" src="https://github.com/user-attachments/assets/8d7a32cb-0be2-408b-bec2-291eb5c19b33" />

4. Listed all SQS queues with names using the `nhs-pr74` prefix to verify that the messages were not sent to the DLQ:
<img width="1637" height="289" alt="Screenshot 2025-08-21 at 16 09 52" src="https://github.com/user-attachments/assets/cb322ae2-d819-41ff-9a64-cbb9e335fbcd" />

5. Checked the logs for the command-processor lambda function to verify the new `Request has already been received by Notify` log was present:
<img width="2227" height="348" alt="Screenshot 2025-08-21 at 16 09 35" src="https://github.com/user-attachments/assets/6171abcb-8187-4b95-9530-816981026998" />

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.