### PR TITLE
CCM-11916: Don't trigger acceptance tests on pushes to main

### DIFF
--- a/.github/workflows/cicd-1-pull-request.yaml
+++ b/.github/workflows/cicd-1-pull-request.yaml
@@ -121,6 +121,7 @@ jobs:
       version: "${{ needs.metadata.outputs.version }}"
     secrets: inherit
   acceptance-stage: # Recommended maximum execution time is 10 minutes
+    # Test change.
     name: "Acceptance stage"
     needs: [metadata, build-stage]
     uses: ./.github/workflows/stage-4-acceptance.yaml

--- a/.github/workflows/cicd-1-pull-request.yaml
+++ b/.github/workflows/cicd-1-pull-request.yaml
@@ -121,7 +121,6 @@ jobs:
       version: "${{ needs.metadata.outputs.version }}"
     secrets: inherit
   acceptance-stage: # Recommended maximum execution time is 10 minutes
-    # Test change.
     name: "Acceptance stage"
     needs: [metadata, build-stage]
     uses: ./.github/workflows/stage-4-acceptance.yaml

--- a/.github/workflows/cicd-1-pull-request.yaml
+++ b/.github/workflows/cicd-1-pull-request.yaml
@@ -124,7 +124,7 @@ jobs:
     name: "Acceptance stage"
     needs: [metadata, build-stage]
     uses: ./.github/workflows/stage-4-acceptance.yaml
-    if: needs.metadata.outputs.does_pull_request_exist == 'true' || (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')) || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: needs.metadata.outputs.does_pull_request_exist == 'true' || (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened'))
     secrets: inherit
     with:
       pr_number: ${{ needs.metadata.outputs.pr_number }}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR updates the `CI/CD pull request` workflow so that the `Acceptance stage` job is no longer run for pushes to the `main` branch.

## Context

Currently this workflow is failing when run for commits to `main`, as the component tests which are triggered by the `Acceptance stage` job are tailored for PR environments only.

## Type of changes

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Validation
Commits to a branch without a PR still **do not** trigger acceptance tests: https://github.com/NHSDigital/nhs-notify-sms-nudge/actions/runs/17321994796
<img width="2478" height="727" alt="Screenshot 2025-08-29 at 12 03 37" src="https://github.com/user-attachments/assets/ce03c6e0-822c-464c-bdef-757d5847c2e8" />

Opening a PR still triggers acceptance tests: https://github.com/NHSDigital/nhs-notify-sms-nudge/actions/runs/17322089814
<img width="2478" height="727" alt="Screenshot 2025-08-29 at 12 13 01" src="https://github.com/user-attachments/assets/be3faf0d-8ed1-4328-9341-a392ae72697e" />

Pushing a commit to a branch with an open PR still triggers acceptance tests: https://github.com/NHSDigital/nhs-notify-sms-nudge/actions/runs/17322295159
<img width="2478" height="727" alt="Screenshot 2025-08-29 at 13 33 30" src="https://github.com/user-attachments/assets/5154a3d0-b112-4d2e-a3bf-50741013ba2e" />

Closing a PR does not trigger acceptance tests:
<img width="1306" height="387" alt="Screenshot 2025-08-29 at 13 35 51" src="https://github.com/user-attachments/assets/44b630cf-14ca-4448-8966-9cc894ec3d35" />
(No CI/CD pull request workflow triggered)

Re-opening a PR triggers acceptance tests: https://github.com/NHSDigital/nhs-notify-sms-nudge/actions/runs/17324107037
<img width="2461" height="730" alt="Screenshot 2025-08-29 at 13 51 44" src="https://github.com/user-attachments/assets/3675d87b-e47e-48e8-b119-2f4406481dd4" />

## Checklist

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
